### PR TITLE
vimc-4209 Support modellers with up to 2 models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site/
+.idea

--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ Posts are created in exactly the same way as regular pages: you still need to ma
 The general layout of the pages can't be changed easily.  But things like colour, spacing, fonts, and any other CSS style can easily be changed by adding CSS rules to the [`vimc.css`](./css/vimc.css) file. For example, you can change the size of the text, or the background colour of the navigation bar, or the colour of the text in the footer.
 
 Note that the template was designed in a way such that it changes drastically when you view it on a big screen (laptop) vs a small screen (phone)
+
+## Local development
+
+To run locally:
+1. Ensure you have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed;
+1. Ensure you have [Bundler](https://bundler.io/) installed.
+1. Ensure you have [Jekyll](https://jekyllrb.com/docs/installation/ubuntu/) installed.
+1. `sudo gem update --system` to get the latest version of gems. 
+1. Run `bundle exec jekyll serve` to run the site. There may be further grumbles about versions, but following instructions should eventually result in a runnable site. 
+1. Site will be available at http://127.0.0.1:4000/
+
+ 
+See [here](https://docs.github.com/en/github/working-with-github-pages/testing-your-github-pages-site-locally-with-jekyll) for more information.

--- a/_data/modellers.yml
+++ b/_data/modellers.yml
@@ -199,7 +199,9 @@
 - name: Justin Lessler   
   url: https://www.jhsph.edu/faculty/directory/profile/2566/justin-lessler   
   title: Rubella model   
-  title_link: /models/rubella   
+  title_link: /models/rubella
+  title2: Cholera model
+  title2_link: /models/cholera
   email:  justin@jhu.edu   
   img: '/img/people/Justin_Lessler.png'   
   

--- a/_includes/list-circles.html
+++ b/_includes/list-circles.html
@@ -18,6 +18,13 @@
 		  <div class="item-desc">{{ item.title }}</div>
 		{% endif %}
       {% endif %}
+      {% if item.title2 %}
+        {% if item.title2_link %}
+          <a href="{{ item.title2_link }}"><div class="item-desc">{{ item.title2 }}</div></a>
+        {% else %}
+          <div class="item-desc">{{ item.title2 }}</div>
+        {% endif %}
+      {% endif %}
       <div class="item-links">
         {% if item.url %}
           <a class="item-link" href="{{ item.url }}" title="Website">


### PR DESCRIPTION
Thuy's original request:
![Screenshot from 2020-08-10 16-33-44](https://user-images.githubusercontent.com/44669576/89801104-99dfa600-db27-11ea-9300-eb7654c2dbb6.png)

Kim and Thuy usually make changes directly in the master branch, but for changes to templates at least we should be using branches! This means getting the site running locally so we can test changes. This branch
- adds instructions for running the site on your local machine. 
- updates the list-circles template to allow an optional second 'title' (bad name which I've just compounded, but I don't fancy changing all instances!).
- Makes the change Thuy was attempting above. If you run the site and browse to http://127.0.0.1:4000/modellers/ you should see that Justin Lessler now has a second model (cholera) with working link. 