### PR TITLE
VIMC-4447 Add 'Publications' as a heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-_site/
-.idea
+/_site/
+/.idea
+/.jekyll-cache/

--- a/_config.yml
+++ b/_config.yml
@@ -48,8 +48,8 @@ navbar-links:
     - Typhoid fever: "diseases/typhoid-fever"
     - Yellow fever: "diseases/yellow-fever"
   News: "news"
+  Publications: "publications"
   Resources:
-    - Publications: "publications"   
     - Newsletters: "newsletters"
     - Reports: "reports"
     - Other resources: "resources"
@@ -87,5 +87,5 @@ exclude:
   - LICENSE
   - README.md
 
-gems:
+plugins:
   - jekyll-paginate


### PR DESCRIPTION
This moves Publications to the desired position in the navigation bar

It also updates `_config.yml` to fix deprecation warning with current version of Jekyll used by Pages