### PR TITLE
VIMC-4726 Make website edits by non-dev editors visible without being pushed to live site

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ jobs:
       - run: bundle exec jekyll build
       - run: |
           echo "User-agent: * Disallow: /" >_site/robots.txt
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: vimc/www-preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - preview
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec jekyll build
+      - run: |
+          echo "User-agent: * Disallow: /" >_site/robots.txt
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: vimc/www-preview
+          publish_dir: ./_site
+          cname: www-preview.vaccineimpact.org

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ The general layout of the pages can't be changed easily.  But things like colour
 
 Note that the template was designed in a way such that it changes drastically when you view it on a big screen (laptop) vs a small screen (phone)
 
+## Previewing changes
+
+Any changes made to the `preview` branch will result in a preview of the site being deployed to the [staging site](https://www-preview.vaccineimpact.org/)
+
+In order to use this branch:
+* Ensure that it contains all latest changes from master
+  * This can be accomplished by merging a [PR from `master` to `preview`](https://github.com/vimc/vimc.github.io/compare/preview...master)
+* Make changes to files as usual, but ensuring that the `preview` branch is selected (see [branch selection dropdown](https://docs.github.com/assets/images/help/branch/branch-selection-dropdown.png) in top-left of screen)
+* After a brief delay the changes can be reviewed on the [staging site](https://www-preview.vaccineimpact.org/)
+* Merge the changes into master in order to update the main site
+  * This can be accomplished by merging a [PR from `preview` to `master`](https://github.com/vimc/vimc.github.io/compare/master...preview)
+
 ## Scheduling an update to the site (advanced!)
 
 We have [an Action](https://github.com/vimc/vimc.github.io/blob/master/.github/workflows/publish.yml) than can be


### PR DESCRIPTION
Add `publish` action in `preview.yml` which when triggered by a push to the `preview` branch:
* Installs and runs Jekyll using the existing [Gemfile](https://github.com/vimc/vimc.github.io/blob/master/Gemfile) that includes the `github-pages` gem (i.e. emulates the GitHub Pages environment)
* Creates a `robots.txt` file that prevents search indexing of the preview site
* Pushes the generated site to the `gh-pages` branch of the [www-preview](https://github.com/vimc/www-preview) repository, using a read-write deployment key that is scoped to that repository (which is otherwise read-only)
  * The public key (stored in the `www-preview` repository) and private key (stored in this repository) have been saved in Vault under `secret/vimc/www-preview/deploy`
  * A `CNAME` file is created to ensure that the site appears at https://www-preview.vaccineimpact.org rather than `https://www.vaccineimpact.org/preview` (which would be the default behaviour for GitHub Pages for projects). A corresponding `CNAME` record for `www-preview` has been added to the [vaccineimpact.org DNS settings in Cloudflare](https://dash.cloudflare.com/6101a5c97c3e05e67ae10df5eb9c4102/vaccineimpact.org/dns). Note that the preview site, unlike the live site, isn't proxied by Cloudflare: any reduction in access latency is compensated by faster update times (i.e. less caching) and https is available via GitHub Pages itself nowadays.

Notes:
* This PR has no impact on existing setup until/unless the `preview` branch is updated and even then it only affects the preview site
* The preview site is live but currently empty as it will (hopefully) be populated by this Action on first run
* Further manually-invoked Actions may be necessary to a) pull changes from `master` into `preview` and b) push changes from `preview` into `master`. These would merely be short-cuts for PR process though, so will be done in a follow-up ticket and the README updated accordingly.